### PR TITLE
Add .travis.yaml to automatically test and build the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: d
+
+d:
+  # - ldc-1.8.0 # this has to be the first, because apparently we can't generated docs with other compilers
+  - ldc
+  - dmd
+  - gdc
+
+matrix:
+  allow_failures:
+    - d: gdc
+
+script:
+  - dub run --config=mecca-ut
+
+# notifications:
+    # email:
+        # on_success: change
+        # on_failure: change
+
+# after_success: |-
+  # [[ $TRAVIS_JOB_NUMBER = *.1 ]] && # only generate docs once per commit
+  # [ $TRAVIS_BRANCH = master ] && # don't overwrite the only docs with branches other than master
+  # [ $TRAVIS_PULL_REQUEST = false ] && # don't overwrite the only docs with not-yet-merged pull requests
+  # dub build --build=ddox &&
+  # pip install ghp-import --user && export PATH=$HOME/.local/bin:$PATH &&
+  # ghp-import -n docs &&
+  # git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.org/weka-io/mecca.svg?branch=master)](https://travis-ci.org/weka-io/mecca)
+
 # Mecca - Container/Reactor library for D
 
 You can find the API documentation [here](https://weka-io.github.com/mecca/docs).


### PR DESCRIPTION
* The build is failing with GDC. We can remove this Travis branch, or you can fix it.
* For some reason I can only build the docs with ldc 1.8.0, so I added a special Travis branch for that.
* The badge in the README won't work becase we did not add the main repo to Travis yet. This is how it looks when I redirect it to my fork: [![Build Status](https://api.travis-ci.org/idanarye/mecca.svg?branch=master)](https://travis-ci.org/idanarye/mecca)
* This will upload to the repository's personal `gh-pages` branch, so we might want to remove the global `weka-io/gh-pages` repo (not sure if they'll conflict or not)
* The link to the docs in the README is to the yet-to-be-created gh-pages of the main repo. This is how it looks like in my fork
    Repo: https://github.com/idanarye/mecca/tree/gh-pages
    Rendered: https://idanarye.github.io/mecca/
* Before this can work, we need to enable the main repo on Travis CI and set it's `GH_TOKEN` to a new API token. For some reason API tokens can only be created on user accounts - not on organizations - so I'd rather we create it on your account. I'll show you how.