### PR TITLE
Clean up otm_queue

### DIFF
--- a/src/mecca/containers/otm_queue.d
+++ b/src/mecca/containers/otm_queue.d
@@ -90,7 +90,7 @@ public:
      *
      * Please note that the value returned may change by other threads at any point.
      */
-    @property bool isFull() const nothrow @trusted @nogc {
+    @property bool isFull() const nothrow @safe @nogc {
         // We use raw memory order to make the check cheap: Even if writeIndex is out of date for a producer, the
         // (size - maxQueueCapacity) extra elements make sure it is safe to go ahead with push(). If readIndex is
         // not up to date, a producer might wait unnecessarily long for space to become available, which is not
@@ -116,7 +116,7 @@ public:
      * Returns:
      * true if a value was, indeed, popped from the queue. False if the queue was empty.
      */
-    @notrace bool pop(out T result) nothrow @trusted @nogc {
+    @notrace bool pop(out T result) nothrow @nogc {
         version (unittest) {
             sanity();
             scope(exit) sanity();
@@ -155,7 +155,7 @@ public:
      * Returns:
      * true if value was successfully pushed. False if the queue was full.
      */
-    @notrace bool push(T data) nothrow @trusted @nogc {
+    @notrace bool push(T data) nothrow @nogc {
         DBG_ASSERT!"Must register number of concurrent producers"( producers>0 );
         version (unittest) {
             sanity();
@@ -181,7 +181,7 @@ private:
         return (ptr / size) &1;
     }
 
-    version (unittest) @notrace void sanity() nothrow @system @nogc {
+    version (unittest) @notrace void sanity() nothrow @safe @nogc {
         version(assert) {
             const myReadIndex = atomicLoad!(MemoryOrder.raw)(readIndex);
             const myWriteIndex = atomicLoad!(MemoryOrder.raw)(writeIndex);
@@ -233,7 +233,7 @@ public:
      *
      * Please note that the value returned may change by other threads at any point.
      */
-    @property bool isFull() nothrow @trusted @nogc {
+    @property bool isFull() nothrow @safe @nogc {
         // We use raw memory order to make the check cheap: The worst that can happen is that readIndex
         // lags far behind the consumers, in which case the producer might wait unnecessarily before pushing
         // more elements.
@@ -260,7 +260,7 @@ public:
      * Returns:
      * true if a value was, indeed, popped from the queue. False if failed.
      */
-    @notrace bool pop(out T result) nothrow @trusted @nogc {
+    @notrace bool pop(out T result) nothrow @nogc {
         // See whether there might be data available.
         //
         // A raw load is fine for the read index in terms of correctness, as we will (try to) claim the slot
@@ -306,7 +306,7 @@ public:
      * Returns:
      * true if value was successfully pushed. False if the queue was full.
      */
-    @notrace bool push(T data) nothrow @trusted @nogc {
+    @notrace bool push(T data) nothrow @nogc {
         if (isFull()) {
             return false;
         }

--- a/src/mecca/containers/otm_queue.d
+++ b/src/mecca/containers/otm_queue.d
@@ -185,7 +185,7 @@ private:
         version(assert) {
             const myReadIndex = atomicLoad!(MemoryOrder.raw)(readIndex);
             const myWriteIndex = atomicLoad!(MemoryOrder.raw)(writeIndex);
-            ASSERT!"writeIndex %d < ConsumerPtr %d"(myReadIndex <= myWriteIndex, myReadIndex, myWriteIndex);
+            ASSERT!"readIndex %d > writeIndex %d"(myReadIndex <= myWriteIndex, myReadIndex, myWriteIndex);
         }
         // Since we don't want to enforce SC on the consumer pointer, we cannot be sure of an override,
         // this is JUST a speculation, the following assert should remain commented out.

--- a/src/mecca/containers/otm_queue.d
+++ b/src/mecca/containers/otm_queue.d
@@ -38,12 +38,12 @@ struct SCMPQueue(T, size_t size)
             __traits( compiles, { shared T t; atomicLoad!(MemoryOrder.raw)(t); } ), "T is incompatible with atomic operations" );
 
 private:
-    static struct QueueNode {
+    static struct Slot {
         shared ubyte phase = 1;
         T data;
     }
 
-    QueueNode[size] queue;
+    Slot[size] queue;
     shared ulong readIndex;
     shared ulong writeIndex;
 
@@ -215,12 +215,12 @@ struct MCSPQueue(T, size_t size)
     static assert(
             __traits( compiles, { shared T t; atomicLoad!(MemoryOrder.raw)(t); } ), "T is incompatible with atomic operations" );
 private:
-    static struct QueueNode {
+    static struct Slot {
         shared ubyte phase = 0;
         T data;
     }
 
-    QueueNode[size] queue;
+    Slot[size] queue;
     shared ulong readIndex;
     shared ulong writeIndex;
 

--- a/src/mecca/containers/otm_queue.d
+++ b/src/mecca/containers/otm_queue.d
@@ -27,15 +27,13 @@ private enum UtExtraDebug = false;
  * Single consumer multiple producers queue
  *
  * Params:
- * T = the type handled by the queue. Must be one that supports atomic operations.
+ * T = the type handled by the queue.
  * size = the number of raw elements in the queue (actual queue size will be somewhat smaller). Must be a power of 2.
  */
 struct SCMPQueue(T, size_t size)
 {
     // This is "just" a performance issue rather than an actual problem. It is a major performance issue, however.
     static assert( (size & -size) == size, "One to many queue size not a power of 2" );
-    static assert(
-            __traits( compiles, { shared T t; atomicLoad!(MemoryOrder.raw)(t); } ), "T is incompatible with atomic operations" );
 
 private:
     static struct Slot {
@@ -199,15 +197,14 @@ private:
  * Multiple consumers single producer queue
  *
  * Params:
- * T = the type handled by the queue. Must be one that supports atomic operations.
+ * T = the type handled by the queue.
  * size = the number of raw elements in the queue (actual queue size will be somewhat smaller). Must be a power of 2.
  */
 struct MCSPQueue(T, size_t size)
 {
     // This is a performance issue rather than an actual problem. It is a major performance issue, however.
     static assert( (size & -size) == size, "One to many queue size not a power of 2" );
-    static assert(
-            __traits( compiles, { shared T t; atomicLoad!(MemoryOrder.raw)(t); } ), "T is incompatible with atomic operations" );
+
 private:
     static struct Slot {
         shared ubyte phase = 0;

--- a/src/mecca/containers/otm_queue.d
+++ b/src/mecca/containers/otm_queue.d
@@ -49,8 +49,8 @@ private:
 
     // No synchronization here because the number of producers is constant while multiple threads are
     // accessing the object.
-    ulong producers;
     size_t maxQueueCapacity = size - 1;
+    @property producers() pure const nothrow @safe @nogc { return size - 1 - maxQueueCapacity; }
 
 public:
     /**
@@ -65,16 +65,10 @@ public:
      */
     void addProducers(size_t numProducers) nothrow @nogc @safe {
         ASSERT!"addProducer called on an already active queue"(readIndex==0 && writeIndex==0);
+        const newCapacity = maxQueueCapacity - numProducers;
         DBG_ASSERT!"Cannot register %s producers on queue of size %s with %s producers already"
-                ( numProducers+producers < size/2, numProducers, size, producers );
-        producers += numProducers;
-        maxQueueCapacity -= numProducers;
-        DBG_ASSERT!"queue capacity calculation is off. Capacity %s size %s producers %s registered now %s"
-                ( maxQueueCapacity == size - producers - 1,
-                  maxQueueCapacity,
-                  size,
-                  producers,
-                  numProducers );
+                (newCapacity >= size / 2, numProducers, size, producers);
+        maxQueueCapacity = newCapacity;
     }
 
     /// ditto


### PR DESCRIPTION
This removes a few remnants from before OtMQueue was split (which is indeed a good idea), clarifies some comments, and allows non-`core.atomic`-compatible element types.

I'll probably post another PR that briefly explains the implementation ("phases"/…) tomorrow.