### PR TITLE
Fix build with -dip25 and prevent regressions

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -2,6 +2,7 @@
     "name": "mecca",
     "importPaths": ["src"],
     "sourcePaths": ["src"],
+    "dflags" : ["-dip25"],
     "description" : "Mecca - Weka's reactor and infrastructure library",
     "copyright": "Copyright © 2017-2018, Weka.IO Ltd.",
     "license": "Boost",

--- a/src/mecca/lib/exception.d
+++ b/src/mecca/lib/exception.d
@@ -113,7 +113,7 @@ struct DefaultTraceInfoABI {
     static DefaultTraceInfoABI* extract(Throwable ex) nothrow @safe @nogc {
         return extract(ex.info);
     }
-    @property void*[] frames() nothrow @trusted @nogc {
+    @property void*[] frames() return nothrow @trusted @nogc {
         return callstack.ptr[0 .. numframes];
     }
 }
@@ -129,7 +129,7 @@ struct ExcBuf {
     char[MAX_EXCEPTION_MESSAGE_SIZE] msgBuf;
 
     /// Get the Throwable stored in the buffer
-    Throwable get() nothrow @trusted @nogc {
+    Throwable get() return nothrow @trusted @nogc {
         if (*(cast(void**)ex.ptr) is null) {
             return null;
         }

--- a/src/mecca/lib/net.d
+++ b/src/mecca/lib/net.d
@@ -47,22 +47,22 @@ struct IPv4 {
     }
 
     /// Assignment
-    ref typeof(this) opAssign(uint netOrder) pure nothrow @safe @nogc {
+    ref typeof(this) opAssign(uint netOrder) return pure nothrow @safe @nogc {
         inaddr.s_addr = netOrder;
         return this;
     }
     /// ditto
-    ref typeof(this) opAssign(ubyte[4] bytes) pure nothrow @safe @nogc {
+    ref typeof(this) opAssign(ubyte[4] bytes) return pure nothrow @safe @nogc {
         this.bytes = bytes;
         return this;
     }
     /// ditto
-    ref typeof(this) opAssign(in_addr ia) pure nothrow @safe @nogc {
+    ref typeof(this) opAssign(in_addr ia) return pure nothrow @safe @nogc {
         inaddr = ia;
         return this;
     }
     /// ditto
-    ref typeof(this) opAssign(string dottedString) @trusted @nogc {
+    ref typeof(this) opAssign(string dottedString) return @trusted @nogc {
         int res = inet_pton(AF_INET, ToStringz!INET_ADDRSTRLEN(dottedString), &inaddr);
 
         DBG_ASSERT!"Invalid call to inet_pton"(res>=0);

--- a/src/mecca/lib/reflection.d
+++ b/src/mecca/lib/reflection.d
@@ -1025,7 +1025,7 @@ unittest {
 
         @property bool empty() { return true; }
 
-        @property ref int front() { return a; }
+        @property ref int front() return { return a; }
     }
 
     static assert( isRefInputRange!S );

--- a/src/mecca/reactor/io/fd.d
+++ b/src/mecca/reactor/io/fd.d
@@ -386,7 +386,7 @@ struct Socket {
             @trusted @nogc
     {
         return fd.blockingCall!(.sendto)(
-                Direction.Write, data.ptr, data.length, flags, &destAddr.base, SockAddr.sizeof, timeout); 
+                Direction.Write, data.ptr, data.length, flags, &destAddr.base, SockAddr.sizeof, timeout);
     }
 
     /// ditto
@@ -705,7 +705,7 @@ public:
     }
 
     /// Move semantics opAssign
-    ref ReactorFD opAssign(ReactorFD rhs) nothrow @safe @nogc {
+    ref ReactorFD opAssign(ReactorFD rhs) return nothrow @safe @nogc {
         swap( rhs.fd, fd );
         swap( rhs.ctx, ctx );
 
@@ -730,7 +730,7 @@ public:
     }
 
     /// Returns the underlying mecca.lib.io.FD
-    @property ref FD get() nothrow @safe @nogc {
+    @property ref FD get() return nothrow @safe @nogc {
         return fd;
     }
 


### PR DESCRIPTION
Functions that return by `ref` their formal parameters (or the `this` implicit parameter) need to have the `return` attribute, so the compiler can catch cases where the return value outlives the function argument it
was derived from. This attribute is inferred (just like e.g. `nothrow` or `pure`) for function templates (or functions defined inside templates), nested functions and `auto`-returning functions.
The `-dip25` flag enforces this static analysis and it will become the default in one the future releases. 

This pull request enables this flag and fixes the compilation errors.

We're currently in the process of fixing projects on [BuildKite](https://buildkite.com/dlang/dmd/builds/3519) such as yours, in order to ease the community for the transition. The transition is most likely going to happen through a deprecation phase (e.g. it won't be a hard-error for one more releases), but it's a good idea to prepare in advance.