### PR TITLE
Support for Druntime PR 2645

### DIFF
--- a/src/mecca/lib/exception.d
+++ b/src/mecca/lib/exception.d
@@ -702,8 +702,3 @@ unittest {
     // double close will throw
     assertThrows!ErrnoException(errnoCall!close(newFd));
 }
-
-
-
-
-

--- a/src/mecca/lib/exception.d
+++ b/src/mecca/lib/exception.d
@@ -34,8 +34,11 @@ private extern(C) nothrow @nogc {
     static if (__VERSION__ < 2077) {
         pragma(mangle, "_D4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo6__ctorMFZC4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo")
             void defaultTraceInfoCtor(Object);
-    } else {
+    } else static if (__VERSION__ < 2087) {
         pragma(mangle, "_D4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo6__ctorMFZCQCpQCnQCiFQBqZQBr")
+            void defaultTraceInfoCtor(Object);
+    } else {
+        pragma(mangle, "_D4core7runtime16DefaultTraceInfo6__ctorMFZCQBqQBoQBj")
             void defaultTraceInfoCtor(Object);
     }
 }

--- a/src/mecca/lib/exception.d
+++ b/src/mecca/lib/exception.d
@@ -27,6 +27,7 @@ import mecca.lib.string : nogcFormat, nogcRtFormat;
 
 private bool _assertInProgress;
 
+// The default TraceInfo provided by DMD is not `@nogc`
 private extern(C) nothrow @nogc {
     int backtrace(void** buffer, int size);
 


### PR DESCRIPTION
- Removed a bunch of trailing whitespace
- Documented the reason for the mangling: If someone ever wants to remove the hack, be it within Weka or outside, it would be good for them to quickly find out why it is there to begin with. In fact the PR I am linking is a base on work I'm doing for a similar needs.
- Add support so that dlang/druntime#2645 passes on Buildkite (current `__VERSION__` == 2087)