### PR TITLE
Move Travis CI tests to CircleCI for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,55 @@
+workflows:
+  version: 2
+  test:
+    jobs:
+      - ldc-beta
+      - ldc
+      - ldc-1.8.0 # Weka's current compiler is based on this compiler
+      - dmd-beta
+      - dmd
+
+shared: &shared
+  macos:
+    xcode: "10.2.1"
+  steps:
+    - run:
+        name: Install gnupg
+        command: brew install gnupg
+    - run:
+        name: Install D Compiler
+        command: curl -fsS https://dlang.org/install.sh | bash -s ${CIRCLE_JOB}
+    - checkout
+    - run:
+        name: Run Unit Tests
+        command: |
+          source $(~/dlang/install.sh ${CIRCLE_JOB} -a)
+          dub run --config=mecca-ut
+    - run:
+        name: Build lordcmdr
+        command: |
+          source $(~/dlang/install.sh ${CIRCLE_JOB} -a)
+          dub build --config=lordcmdr
+    - run:
+        name: Build sleeper
+        command: |
+          source $(~/dlang/install.sh ${CIRCLE_JOB} -a)
+          dub build --config=sleeper
+    - run:
+        name: Build echo-server
+        command: |
+          source $(~/dlang/install.sh ${CIRCLE_JOB} -a)
+          dub build --config=echo-server
+
+version: 2
+jobs:
+  ldc-beta:
+    <<: *shared
+  ldc:
+    <<: *shared
+  ldc-1.8.0:
+    <<: *shared
+  dmd-beta:
+    <<: *shared
+  dmd:
+    <<: *shared
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ d:
 
 os:
   - linux
-  - osx
 
 matrix:
   allow_failures:


### PR DESCRIPTION
The tests fail on Travis CI for macOS. It might be due to the virtual machines are slower than on CircleCI.

Someone with permission would need to login to CircleCI and setup Mecca as a project.