### PR TITLE
Correct version number on pragma mangle

### DIFF
--- a/src/mecca/lib/exception.d
+++ b/src/mecca/lib/exception.d
@@ -34,7 +34,7 @@ private extern(C) nothrow @nogc {
     static if (__VERSION__ < 2077) {
         pragma(mangle, "_D4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo6__ctorMFZC4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo")
             void defaultTraceInfoCtor(Object);
-    } else static if (__VERSION__ < 2087) {
+    } else static if (__VERSION__ < 2088) {
         pragma(mangle, "_D4core7runtime19defaultTraceHandlerFPvZ16DefaultTraceInfo6__ctorMFZCQCpQCnQCiFQBqZQBr")
             void defaultTraceInfoCtor(Object);
     } else {


### PR DESCRIPTION
```
Pull request 21 used the wrong VERSION statement, as the PR didn't make it to 2087.
This can be observed on the dmd-beta fail on Travis, and soon DMD will start to fail.
```

Sorry for the back & forth, can I get another tag ? Currently dlang's `stable` is failing because of this.