### PR TITLE
Fix mecca documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 # Mecca - Container/Reactor library for D
 
-You can find the API documentation [here](https://weka-io.github.com/mecca/docs).
+You can find the API documentation [here](https://weka-io.github.io/mecca/docs/).


### PR DESCRIPTION
The `github.com` host has been deprecated for user sites. Site is accessible at https://weka-io.github.io/mecca/docs/ instead.